### PR TITLE
Added BibTex Tests and corrected a minor error formatting authors

### DIFF
--- a/model/styles/biblatexSoftware.js
+++ b/model/styles/biblatexSoftware.js
@@ -59,7 +59,7 @@ class BibTexSoftware extends Style {
         returnString += ' and ';
       }
       else if (!array.isLastIndex(index)) {
-        returnString += ', ';
+        returnString += ' and ';
       }
     });
     returnString += '}';

--- a/model/styles/bibtexMisc.js
+++ b/model/styles/bibtexMisc.js
@@ -57,7 +57,7 @@ class BibTexMisc extends Style {
         returnString += ' and ';
       }
       else if (!array.isLastIndex(index)) {
-        returnString += ', ';
+        returnString += ' and ';
       }
     });
     returnString += '}';

--- a/test/styles/bibtex.js
+++ b/test/styles/bibtex.js
@@ -1,3 +1,5 @@
+/* global it describe */
+
 const assert = require('assert');
 const bibtexmisc = require('../../model/styles/bibtexMisc');
 const biblatexSoftware = require('../../model/styles/biblatexSoftware');
@@ -7,63 +9,56 @@ const threeAuthorsSourceData = require('../mockSourceData/allFieldsThreeAuthors'
 
 describe('BibTexMiscStyle', () => {
   describe('format', () => {
+    const formattedString = bibtexmisc.format(oneAuthorSourceData);
     it('Month field, one author', () => {
-      const formattedString = bibtexmisc.format(oneAuthorSourceData);
       assert.equal(formattedString.includes('month = {11},'), true);
     });
 
     it('Title field one author', () => {
-      const formattedString = bibtexmisc.format(oneAuthorSourceData);
       assert.equal(formattedString.includes('title = {Red Barchetta},'), true);
     });
 
     it('Author field, one author', () => {
-      const formattedString = bibtexmisc.format(oneAuthorSourceData);
       assert.equal(formattedString.includes('author = {Lee, Geddy},'), true);
     });
 
     it('Note field, one author', () => {
-      const formattedString = bibtexmisc.format(oneAuthorSourceData);
       assert.equal(formattedString.includes('note = {Version: 1.0.0, URL: http://myUnclesFarm.com}'), true);
     });
     // Three Authors
+    const formattedStringThreeAuthor = bibtexmisc.format(threeAuthorsSourceData);
     it('Author field, three authors', () => {
-      const formattedString = bibtexmisc.format(threeAuthorsSourceData);
-      assert.equal(formattedString.includes('author = {Lee, Geddy and Lifeson, Alex and Peart, Neil},'), true);
+      assert.equal(formattedStringThreeAuthor.includes('author = {Lee, Geddy and Lifeson, Alex and Peart, Neil},'), true);
     });
   });
 });
 
 describe('BibLatexSoftwareStyle', () => {
   describe('format', () => {
+    const formattedString = biblatexSoftware.format(oneAuthorSourceData);
     it('Month field, one author', () => {
-      const formattedString = biblatexSoftware.format(oneAuthorSourceData);
       assert.equal(formattedString.includes('month = {11},'), true);
     });
 
     it('Title field one author', () => {
-      const formattedString = biblatexSoftware.format(oneAuthorSourceData);
       assert.equal(formattedString.includes('title = {Red Barchetta},'), true);
     });
 
     it('Author field, one author', () => {
-      const formattedString = biblatexSoftware.format(oneAuthorSourceData);
       assert.equal(formattedString.includes('author = {Lee, Geddy},'), true);
     });
 
     it('URL field, one author', () => {
-      const formattedString = biblatexSoftware.format(oneAuthorSourceData);
       assert.equal(formattedString.includes('url = {http://myUnclesFarm.com},'), true);
     });
 
     it('Version field, one author', () => {
-      const formattedString = biblatexSoftware.format(oneAuthorSourceData);
       assert.equal(formattedString.includes('version = {1.0.0}'), true);
     });
       // Three Authors
+    const formattedStringThreeAuthor = biblatexSoftware.format(threeAuthorsSourceData);
     it('Author field, three authors', () => {
-      const formattedString = biblatexSoftware.format(threeAuthorsSourceData);
-      assert.equal(formattedString.includes('author = {Lee, Geddy and Lifeson, Alex and Peart, Neil},'), true);
+      assert.equal(formattedStringThreeAuthor.includes('author = {Lee, Geddy and Lifeson, Alex and Peart, Neil},'), true);
     });
   });
 });

--- a/test/styles/bibtex.js
+++ b/test/styles/bibtex.js
@@ -8,65 +8,62 @@ const threeAuthorsSourceData = require('../mockSourceData/allFieldsThreeAuthors'
 describe('BibTexMiscStyle', () => {
   describe('format', () => {
     it('Month field, one author', () => {
-      let formattedString = bibtexmisc.format(oneAuthorSourceData);
-      assert.equal(formattedString.includes("month = {11},"),true);
-    });
-    
-    it('Title field one author', () => {
-      let formattedString = bibtexmisc.format(oneAuthorSourceData);
-      assert.equal(formattedString.includes("title = {Red Barchetta},"),true);
-    });
-    
-    it('Author field, one author', () => {
-      let formattedString = bibtexmisc.format(oneAuthorSourceData);
-      assert.equal(formattedString.includes("author = {Lee, Geddy},"),true);
-    });
-    
-    it('Note field, one author', () => {
-      let formattedString = bibtexmisc.format(oneAuthorSourceData);
-      assert.equal(formattedString.includes("note = {Version: 1.0.0, URL: http://myUnclesFarm.com}"),true);
-    }); 
-    //Three Authors
-    it('Author field, three authors', () => {
-      let formattedString = bibtexmisc.format(threeAuthorsSourceData);
-      assert.equal(formattedString.includes("author = {Lee, Geddy and Lifeson, Alex and Peart, Neil},"),true);
+      const formattedString = bibtexmisc.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes('month = {11},'), true);
     });
 
+    it('Title field one author', () => {
+      const formattedString = bibtexmisc.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes('title = {Red Barchetta},'), true);
+    });
+
+    it('Author field, one author', () => {
+      const formattedString = bibtexmisc.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes('author = {Lee, Geddy},'), true);
+    });
+
+    it('Note field, one author', () => {
+      const formattedString = bibtexmisc.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes('note = {Version: 1.0.0, URL: http://myUnclesFarm.com}'), true);
+    });
+    // Three Authors
+    it('Author field, three authors', () => {
+      const formattedString = bibtexmisc.format(threeAuthorsSourceData);
+      assert.equal(formattedString.includes('author = {Lee, Geddy and Lifeson, Alex and Peart, Neil},'), true);
+    });
   });
 });
 
 describe('BibLatexSoftwareStyle', () => {
-    describe('format', () => {
-
-      it('Month field, one author', () => {
-        let formattedString = biblatexSoftware.format(oneAuthorSourceData);
-        assert.equal(formattedString.includes("month = {11},"),true);
-      });
-    
-      it('Title field one author', () => {
-        let formattedString = biblatexSoftware.format(oneAuthorSourceData);
-        assert.equal(formattedString.includes("title = {Red Barchetta},"),true);
-      });
-    
-      it('Author field, one author', () => {
-        let formattedString = biblatexSoftware.format(oneAuthorSourceData);
-        assert.equal(formattedString.includes("author = {Lee, Geddy},"),true);
-      });
-      
-      it('URL field, one author', () => {
-        let formattedString = biblatexSoftware.format(oneAuthorSourceData);
-        assert.equal(formattedString.includes("url = {http://myUnclesFarm.com},"),true);
-      });
-
-      it('Version field, one author', () => {
-        let formattedString = biblatexSoftware.format(oneAuthorSourceData);
-        assert.equal(formattedString.includes("version = {1.0.0}"),true);
-      });
-      //Three Authors
-      it('Author field, three authors', () => {
-        let formattedString = biblatexSoftware.format(threeAuthorsSourceData);
-        assert.equal(formattedString.includes("author = {Lee, Geddy and Lifeson, Alex and Peart, Neil},"),true);
-      });
-
+  describe('format', () => {
+    it('Month field, one author', () => {
+      const formattedString = biblatexSoftware.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes('month = {11},'), true);
     });
+
+    it('Title field one author', () => {
+      const formattedString = biblatexSoftware.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes('title = {Red Barchetta},'), true);
+    });
+
+    it('Author field, one author', () => {
+      const formattedString = biblatexSoftware.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes('author = {Lee, Geddy},'), true);
+    });
+
+    it('URL field, one author', () => {
+      const formattedString = biblatexSoftware.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes('url = {http://myUnclesFarm.com},'), true);
+    });
+
+    it('Version field, one author', () => {
+      const formattedString = biblatexSoftware.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes('version = {1.0.0}'), true);
+    });
+      // Three Authors
+    it('Author field, three authors', () => {
+      const formattedString = biblatexSoftware.format(threeAuthorsSourceData);
+      assert.equal(formattedString.includes('author = {Lee, Geddy and Lifeson, Alex and Peart, Neil},'), true);
+    });
+  });
 });

--- a/test/styles/bibtex.js
+++ b/test/styles/bibtex.js
@@ -12,7 +12,7 @@ describe('BibTexMiscStyle', () => {
       assert.equal(formattedString.includes("month = {11},"),true);
     });
     
-    it('Title field one author', () => {
+    it('Title field, one author', () => {
       let formattedString = bibtexmisc.format(oneAuthorSourceData);
       assert.equal(formattedString.includes("title = {Red Barchetta},"),true);
     });

--- a/test/styles/bibtex.js
+++ b/test/styles/bibtex.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const bibtexmisc = require('../../model/styles/bibtexMisc');
+const biblatexSoftware = require('../../model/styles/biblatexSoftware');
+
+const oneAuthorSourceData = require('../mockSourceData/allFieldsOneAuthor');
+const threeAuthorsSourceData = require('../mockSourceData/allFieldsThreeAuthors');
+
+describe('BibTexMiscStyle', () => {
+  describe('format', () => {
+    it('Month field, one author', () => {
+      let formattedString = bibtexmisc.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes("month = {11},"),true);
+    });
+    
+    it('Title field one author', () => {
+      let formattedString = bibtexmisc.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes("title = {Red Barchetta},"),true);
+    });
+    
+    it('Author field, one author', () => {
+      let formattedString = bibtexmisc.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes("author = {Lee, Geddy},"),true);
+    });
+    
+    it('Note field, one author', () => {
+      let formattedString = bibtexmisc.format(oneAuthorSourceData);
+      assert.equal(formattedString.includes("note = {Version: 1.0.0, URL: http://myUnclesFarm.com}"),true);
+    }); 
+    //Three Authors
+    it('Author field, three authors', () => {
+      let formattedString = bibtexmisc.format(threeAuthorsSourceData);
+      assert.equal(formattedString.includes("author = {Lee, Geddy and Lifeson, Alex and Peart, Neil},"),true);
+    });
+
+  });
+});
+
+describe('BibLatexSoftwareStyle', () => {
+    describe('format', () => {
+
+      it('Month field, one author', () => {
+        let formattedString = biblatexSoftware.format(oneAuthorSourceData);
+        assert.equal(formattedString.includes("month = {11},"),true);
+      });
+    
+      it('Title field one author', () => {
+        let formattedString = biblatexSoftware.format(oneAuthorSourceData);
+        assert.equal(formattedString.includes("title = {Red Barchetta},"),true);
+      });
+    
+      it('Author field, one author', () => {
+        let formattedString = biblatexSoftware.format(oneAuthorSourceData);
+        assert.equal(formattedString.includes("author = {Lee, Geddy},"),true);
+      });
+      
+      it('URL field, one author', () => {
+        let formattedString = biblatexSoftware.format(oneAuthorSourceData);
+        assert.equal(formattedString.includes("url = {http://myUnclesFarm.com},"),true);
+      });
+
+      it('Version field, one author', () => {
+        let formattedString = biblatexSoftware.format(oneAuthorSourceData);
+        assert.equal(formattedString.includes("version = {1.0.0}"),true);
+      });
+      //Three Authors
+      it('Author field, three authors', () => {
+        let formattedString = biblatexSoftware.format(threeAuthorsSourceData);
+        assert.equal(formattedString.includes("author = {Lee, Geddy and Lifeson, Alex and Peart, Neil},"),true);
+      });
+
+    });
+});


### PR DESCRIPTION
Bibtex tests designed to test the existence and correct formatting of the tags contained within the bibtex output, without worrying about the arbitrary order.

Also corrected a minor bug with bibTex author formatting. Authors are supposed to always be separated with an 'and'.