### PR TITLE
Pre-commit script not adding files

### DIFF
--- a/dev/pre-commit
+++ b/dev/pre-commit
@@ -16,6 +16,8 @@ for file in ${files}; do
   if [ "$check" == "" ] && [ "$output" != "" ]; then
     passing=false
   fi
+
+  $(git add $file)
 done
 
 if $passing; then


### PR DESCRIPTION
Fixes a bug in the pre-commit linter script where files fixed by the linter were not staged in the current commit.