### PR TITLE
Add support for figshare sources

### DIFF
--- a/citationCore.js
+++ b/citationCore.js
@@ -27,14 +27,14 @@ module.exports = {
     // Strip http:// and www. if they exists
     const urlHandler = UrlResolverManager.getHandler(formatOptions.url);
     if (urlHandler != null) {
-      urlHandler.fetch(formatOptions.token ? formatOptions.token : null, (sourceData, messages) => {
+      urlHandler.fetch((sourceData, messages) => {
         let citation;
         if (sourceData != null) {
           citation = formatOptions.style.format(sourceData);
         }
 
         callback(citation, messages);
-      });
+      }, formatOptions.token ? formatOptions.token : null);
     }
     else {
       callback(null, [new Error(`"${formatOptions.url}" is an unsupported source`)]);

--- a/sourceHandlers/bitBucket.js
+++ b/sourceHandlers/bitBucket.js
@@ -24,7 +24,7 @@ class BitBucketAPIHandler extends SourceHandler {
     this.repoPath = repoPath;
   }
 
-  fetch(token, callback) {
+  fetch(callback) {
     async.parallel([
       // Fetches version data on the Repo
       (cb) => {

--- a/sourceHandlers/figshare.js
+++ b/sourceHandlers/figshare.js
@@ -1,0 +1,71 @@
+const request = require('request');
+const SourceData = require('../model/sourceData');
+const SourceHandler = require('./sourceHandler');
+
+const userAgent = 'SoftwareCitationCore';
+
+/**
+ * URL Handler for figshareAPI
+ * @class FigshareAPIHandler
+ * @memberof sourceHandlers
+ * @augments sourceHandlers.SourceHandler
+ * @property {String} articleID - The ID of the figshare article.
+ */
+class FigshareAPIHandler extends SourceHandler {
+  /**
+   * Creates a FigshareAPIHandler.
+   * @param baseUrl {String} - The Base URL to the API.
+   * @param articleID {String} - The article ID.
+   */
+  constructor(baseUrl, articleID) {
+    super(baseUrl);
+    this.articleID = articleID;
+  }
+
+  /**
+   * Fetches data to be used in the citation from the API, stores it in a SourceData object, and returns that object to
+   * a callback function
+   * @param callback {Function} - the callback function. Consumes a SourceData object and an Error Object
+   */
+  fetch(callback) {
+
+    const options = {
+      url: this.url + 'articles/' + this.articleID,
+      headers: {
+        'User-Agent': userAgent,
+      },
+    };
+
+    request(options, (error, response, body) => {
+      const parsedBody = (body != null) ? JSON.parse(body) : null;
+
+      if (error == null && response.statusCode !== 200) {
+        callback(null, [new Error('Received a ' + response.statusCode + ' when making a request to ' + options.url)]);
+      }
+      else if (error != null) {
+        callback(null, [error]);
+      }
+      else {
+        const sourceData = new SourceData();
+
+        sourceData.name = parsedBody.figshare_url.replace(/\/\d+$/,'').replace(/^https?:\/\/(www\.)?figshare\.com\/articles\//, '').replace(/_/g, ' ');;
+        sourceData.version = parsedBody.version.toString();
+        sourceData.releaseDate = new Date(parsedBody.modified_date);
+        sourceData.url = parsedBody.url_public_html;
+        sourceData.licence = parsedBody.license.name;
+        sourceData.description = parsedBody.description;
+        // TODO: (Issue #69) Replace with a uid object.
+        sourceData.uid = parsedBody.doi;
+
+        sourceData.authors = parsedBody.authors.map((author) => {
+          return this._createAuthorObj(author, null);
+        });
+
+        callback(sourceData, []);
+      }
+
+    });
+  }
+}
+
+module.exports = FigshareAPIHandler;

--- a/sourceHandlers/gitHub.js
+++ b/sourceHandlers/gitHub.js
@@ -23,7 +23,7 @@ class GitHubAPIHandler extends SourceHandler {
     this.repoPath = repoPath;
   }
 
-  fetch(token, callback) {
+  fetch(callback, token) {
     // Setup async operation functions
     const fetchGeneralInfo = (cb) => {
       this._sendApiRequest(`repos/${this.repoPath}`, token, cb);
@@ -121,16 +121,7 @@ class GitHubAPIHandler extends SourceHandler {
 
     // Execute those requests in parallel and generate the generic user objects
     async.parallel(userFetchOperations, (error, results) => {
-      callback(error, results.map((obj) => {
-        const namePieces = (obj.name != null && typeof (obj.name) === 'string') ? obj.name.split(' ') : [];
-
-        return {
-          lastName: (namePieces.length > 0) ? namePieces.pop() : null,
-          middleName: (namePieces.length > 1) ? namePieces.splice(1 - namePieces.length).join(' ') : null,
-          firstName: (namePieces.length > 0) ? namePieces.pop() : null,
-          email: obj.email,
-        };
-      }));
+      callback(error, results.map((obj) => this._createAuthorObj(obj.name, obj.email);
     });
   }
 }

--- a/sourceHandlers/sourceHandler.js
+++ b/sourceHandlers/sourceHandler.js
@@ -21,6 +21,23 @@ class SourceHandler {
   fetch(callback) {
     throw new Error(`${String(this)} does not implement fetch method`);
   }
+
+  /**
+   * Creates a SourceData author object from a string containing a full name and a string containing an email address.
+   * @param nameStr {string} - A string containg a full name
+   * @param email {string} - A string containing an email address
+   */
+    _createAuthorObj(nameStr, email) {
+      const namePieces = (nameStr != null && nameStr != '' && typeof (nameStr) === 'string') ? nameStr.split(' ') : [];
+      const result = {};
+
+      result.lastName = (namePieces.length > 0) ? namePieces.pop() : null;
+      result.middleName = (namePieces.length > 1) ? namePieces.splice(1 - namePieces.length).join(' ') : null;
+      result.firstName = (namePieces.length > 0) ? namePieces.pop() : null;
+      result.email = email;
+
+      return result;
+   }
 }
 
 /**

--- a/test/testSourceHandlers/basicCitationHandler.js
+++ b/test/testSourceHandlers/basicCitationHandler.js
@@ -6,10 +6,10 @@ class BasicCitationHandler extends SourceHandler {
     return url === 'test://basic';
   }
 
-  static fetch(url, cb) {
+  static fetch(cb) {
     const sourceData = new SourceData();
     sourceData.name = 'basic';
-    sourceData.authors = [{ name: 'Geddy Lee', email: 'geddy@rush.com' }];
+    sourceData.authors = [{ firstName: 'Geddy', middleName: null, lastName: 'Lee', email: 'geddy@rush.com' }];
     sourceData.version = '1.0.0';
     sourceData.releaseDate = new Date(2112, 12, 21);
     sourceData.url = 'http://rush.com';

--- a/test/urlResolverManager.js
+++ b/test/urlResolverManager.js
@@ -1,6 +1,7 @@
 /* global describe it */
 
 const assert = require('assert');
+const FigshareHandler = require('../sourceHandlers/figshare');
 const GitHubHandler = require('../sourceHandlers/gitHub');
 const UrlResolverManager = require('../urlResolverManager');
 
@@ -9,6 +10,11 @@ describe('UrlResolverManager', () => {
     it('returns an instance of GitHubHandler when given a GitHub URL', () => {
       const handler = UrlResolverManager.getHandler('http://github.com/apple/swift/');
       assert(handler.constructor === GitHubHandler);
+    });
+
+    it('returns an instance of FigshareHandler when given a figshare URL', () => {
+      const handler = UrlResolverManager.getHandler('https://figshare.com/articles/4426703');
+      assert(handler.constructor === FigshareHandler);
     });
 
     it('returns null for unknown URL', () => {

--- a/urlResolverManager.js
+++ b/urlResolverManager.js
@@ -1,7 +1,8 @@
-const GithubAPI = require('./urlResolvers/gitHub');
 const BitBucketAPI = require('./urlResolvers/bitBucket');
+const FigshareAPI = require('./urlResolvers/figshare');
+const GithubAPI = require('./urlResolvers/gitHub');
 
-const resolvers = [GithubAPI, BitBucketAPI];
+const resolvers = [BitBucketAPI, FigshareAPI, GithubAPI];
 
 /**
  * A module for resolving a URL to a source handler.

--- a/urlResolvers/figshare.js
+++ b/urlResolvers/figshare.js
@@ -1,0 +1,28 @@
+const URLResolver = require('./urlResolver');
+const FigshareAPIHandler = require('../sourceHandlers/figshare');
+
+const stripHttp = /^(https?:\/\/)?(www\.)?/;
+const urlRegex = /^figshare\.com\/articles(\/\w+)?\/\d+$/;
+
+const apiBaseUrl = 'https://api.figshare.com/v2/';
+
+/**
+ * Creates the supported source handlers for a given URL.
+ * @class
+ * @memberof urlResolvers
+ * @augments urlResolvers.URLResolver
+ */
+class FigshareResolver extends URLResolver {
+  static getSourceHandlers(url) {
+    const sourceHandlers = [];
+    const strippedURL = url.replace(stripHttp, '');
+
+    if (urlRegex.exec(strippedURL)) {
+      sourceHandlers.push(new FigshareAPIHandler(apiBaseUrl, /\d+$/.exec(strippedURL)));
+    }
+
+    return sourceHandlers;
+  }
+}
+
+module.exports = FigshareResolver;


### PR DESCRIPTION
- Adds a URL resolver and source handler for figshare sources, allowing figshare URLs to be cited by CitationCore.
- Adds FigshareHandler to the UrlResolverManager
- Adds a test to the UrlResolverManager test to test that the FigshareHandler is returned for a figshare URL.

This resolves mozillascience/software-citation-tools#20