### PR TITLE
Added a quick syntax fix in the GitHub source handler

### DIFF
--- a/sourceHandlers/gitHub.js
+++ b/sourceHandlers/gitHub.js
@@ -121,7 +121,7 @@ class GitHubAPIHandler extends SourceHandler {
 
     // Execute those requests in parallel and generate the generic user objects
     async.parallel(userFetchOperations, (error, results) => {
-      callback(error, results.map((obj) => this._createAuthorObj(obj.name, obj.email);
+      callback(error, results.map((obj) => this._createAuthorObj(obj.name, obj.email)));
     });
   }
 }


### PR DESCRIPTION
Introduced a syntax error while modifying the GitHub Source Handler to use the _createAuthorObj() method.

This should fix it.